### PR TITLE
relax requirements, avoid hardpinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,13 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-click = "^7.1.1"
+python = ">=3.8"
+click = ">=7.1.1"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.2"
-flake8 = "^3.7.9"
-black = "^19.10b0"
+pytest = ">=5.2"
+flake8 = ">=3.7.9"
+black = ">=19.10b0"
 
 [tool.poetry.scripts]
 xdg-open = 'xdg_open_wsl:main'


### PR DESCRIPTION
poetry promotes the very bad practice of hardpinning tight ranges,
and declaring packages incompatible  with non-existing future releases, that likely will be very compatible.

this PR remove upper bound pinning.